### PR TITLE
Improve Codex deployment layout

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9-slim
+FROM python:3.11-slim
 
 # Set working directory
 WORKDIR /app
@@ -15,6 +15,7 @@ COPY app.py .
 COPY skb_visualization.py .
 COPY templates templates/
 COPY static static/
+COPY Procfile Procfile
 
 # Expose the port the app runs on
 EXPOSE 5000
@@ -24,4 +25,4 @@ ENV PYTHONUNBUFFERED=1
 ENV FLASK_APP=app.py
 
 # Run the application with Gunicorn
-CMD ["gunicorn", "--bind", "0.0.0.0:5000", "--workers", "2", "--timeout", "120", "app:app"]
+CMD ["gunicorn", "--bind", "0.0.0.0:${PORT:-5000}", "--workers", "2", "--timeout", "120", "app:app"]

--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,2 @@
+web: gunicorn --bind 0.0.0.0:${PORT:-5000} app:app
+

--- a/app.py
+++ b/app.py
@@ -5,6 +5,7 @@ import json
 import traceback
 import logging
 import random
+import os
 
 # Configure logging
 logging.basicConfig(level=logging.INFO, 
@@ -12,6 +13,11 @@ logging.basicConfig(level=logging.INFO,
 logger = logging.getLogger(__name__)
 
 app = Flask(__name__)
+
+
+def create_app():
+    """Application factory used for Codex deployment."""
+    return app
 
 # Function to generate data for a twisted strip (sub-SKB) with multi-dimensional twists, time, and loops
 def generate_twisted_strip(twists, t, loop_factor):
@@ -580,4 +586,6 @@ def get_visualization():
         return jsonify({'error': str(e)})
 
 if __name__ == '__main__':
-    app.run(host='0.0.0.0', port=5000, debug=True)
+    port = int(os.environ.get("PORT", 5000))
+    debug = os.environ.get("FLASK_DEBUG", "false").lower() == "true"
+    app.run(host='0.0.0.0', port=port, debug=debug)


### PR DESCRIPTION
## Summary
- add `create_app` factory for Codex
- adjust runtime port selection via environment variables
- include `Procfile` for process startup
- update Dockerfile for Python 3.11 and environment variable port binding

## Testing
- `python -m py_compile app.py`
