### PR TITLE
Improve plot responsiveness and unify Plotly version

### DIFF
--- a/static/js/evolution.js
+++ b/static/js/evolution.js
@@ -1970,4 +1970,12 @@ document.addEventListener('DOMContentLoaded', function() {
     } catch (error) {
         console.error("Error initializing Evolution UI:", error);
     }
-}); 
+
+    // Resize the main plot when the window size changes
+    window.addEventListener('resize', function() {
+        const plot = document.getElementById('evolution-plot');
+        if (plot) {
+            Plotly.Plots.resize(plot);
+        }
+    });
+});

--- a/static/js/oscillator.js
+++ b/static/js/oscillator.js
@@ -314,7 +314,16 @@ document.addEventListener('DOMContentLoaded', function() {
         Plotly.update(imagPlot, {
             y: [imags, envelopes, envelopes.map(v => -v)]
         }, {});
-        
+
         updateAnimation(currentTime);
     }
-}); 
+
+    // Resize plots when the window size changes
+    window.addEventListener('resize', function() {
+        [plot3d, spiralPlot, realPlot, imagPlot].forEach(div => {
+            if (div) {
+                Plotly.Plots.resize(div);
+            }
+        });
+    });
+});

--- a/templates/evolution.html
+++ b/templates/evolution.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 {% block title %}SKB Evolution{% endblock %}
 {% block head_extra %}
-<script src="https://cdn.plot.ly/plotly-latest.min.js"></script>
+<script src="https://cdn.plot.ly/plotly-2.27.0.min.js"></script>
 <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/mathjs/11.8.0/math.min.js"></script>
 <script src="{{ url_for('static', filename='js/plotly-defaults.js') }}"></script>

--- a/templates/maxwell.html
+++ b/templates/maxwell.html
@@ -2,7 +2,7 @@
 {% block title %}Maxwell-Boltzmann Distribution Visualization{% endblock %}
 {% block head_extra %}
 <link rel="stylesheet" href="/static/css/main.css">
-<script src="https://cdn.plot.ly/plotly-latest.min.js"></script>
+<script src="https://cdn.plot.ly/plotly-2.27.0.min.js"></script>
 <script src="{{ url_for('static', filename='js/plotly-defaults.js') }}"></script>
     <style>
         

--- a/templates/quantum_tunneling.html
+++ b/templates/quantum_tunneling.html
@@ -9,7 +9,6 @@
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/normalize/8.0.1/normalize.min.css">
 <link rel="stylesheet" href="{{ url_for('static', filename='css/main.css') }}">
-<script src="https://cdn.plot.ly/plotly-latest.min.js"></script>
 <script src="{{ url_for('static', filename='js/plotly-defaults.js') }}"></script>
 <style>
         

--- a/templates/topological_diffusion.html
+++ b/templates/topological_diffusion.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 {% block title %}4D Manifold Explorer - Topological Diffusion GAN{% endblock %}
 {% block head_extra %}
-<script src="https://cdn.plot.ly/plotly-latest.min.js"></script>
+<script src="https://cdn.plot.ly/plotly-2.27.0.min.js"></script>
 <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/mathjs/11.8.0/math.min.js"></script>
 <script src="{{ url_for('static', filename='js/plotly-defaults.js') }}"></script>


### PR DESCRIPTION
## Summary
- use Plotly 2.27.0 consistently across templates
- remove duplicate Plotly include in `quantum_tunneling.html`
- make oscillator plots responsive to window size
- resize evolution plot on window resize

## Testing
- `python -m py_compile app.py skb_visualization.py`
